### PR TITLE
make account names unique

### DIFF
--- a/extract_otp_secret_keys.py
+++ b/extract_otp_secret_keys.py
@@ -153,7 +153,7 @@ for line in (line.strip() for line in otpauth_list):
         if args.htmlfile:
             with open(args.htmlfile, 'a') as f2:
                 # Create html file with seed info in QR format
-                keyURI = "otpauth://totp/"+otp.name+"?secret="+secret  # +"?issuer="+otp.issuer
+                keyURI = "otpauth://totp/"+str(line_count+j)+(otp.issuer if otp.issuer else otp.name)+"?secret="+secret  # +"?issuer="+otp.issuer
                 # Generate QR code image
                 from qrcode import QRCode
                 import qrcode.image.svg


### PR DESCRIPTION
Some devices (e.g. Reiner SCT) dont get along with non-unique account names. e.g. if one uses TWO microsoft accounts where the issuer is "Microsoft" both times, Reiner SCT only imports one account